### PR TITLE
gmakemake

### DIFF
--- a/makemake/makemake.cpp
+++ b/makemake/makemake.cpp
@@ -8,86 +8,161 @@
  *
  */
 
+#include <string.h>
 #include <iostream>
 #include <cstdlib>
 
 #include "dirlist.h"
 #include "write.h"
 
-bool debug( false );
+void printHelp()
+{
+	cout<<"#Usage: makemake [flag1] [flag2] [...] [>Makefile]"<<endl;
+	cout<<"#Notes: "<<endl;
+	cout<<"#    Flag collision is not checked, previous flags are overridden."<<endl;
+	cout<<"#    On windows, having sh.exe in the path may cause problems."<<endl;
+	cout<<"#Flags Are:"<<endl;
+	cout<<"#    -help                       Prints this help message"<<endl;
+	cout<<"#"<<endl;
+	cout<<"#    -header <filename>          Sets custom header file"<<endl;
+	cout<<"#    -programs <filename>        Sets custom programs file"<<endl;
+	cout<<"#    -custom_targets <filename>  Sets custom targets file"<<endl;
+	cout<<"#"<<endl;
+	cout<<"#    -no-header                  Don't use custom header file"<<endl;
+	cout<<"#    -no-programs                Don't use custom programs file"<<endl;
+	cout<<"#    -no-custom_targets          Don't use custom targets file"<<endl;
+	cout<<"#"<<endl;
+	cout<<"#    -no-debug                   Build without debug info"<<endl;
+	cout<<"#"<<endl;
+	cout<<"#    -win                        Use Windows CMD.exe commands"<<endl;
+	cout<<"#    -linux                      Use Unix bash commands"<<endl;
+	cout<<"#"<<endl;
+	cout<<"#    -gcc                        Use GCC as compiler"<<endl;
+	cout<<"#    -clang                      Use Clang as compiler"<<endl;
+	cout<<"#    -sun                        Use SUN as compiler"<<endl;
 
-int main( int argc, char **argv ){
-  string header_file( "header.mak" );
-  string programs_file( "programs.mak" );
-  string custom_targets_file("custom_targets.mak");
+}
 
-  // Flag indicates whether the CCFLAGS and CFLAGS output should
-  // have -g debugging option omitted
-  bool noDebugFlag( false );
+int main(int argc, char **argv)
+{
+	string header_file("header.mak");
+	string programs_file("programs.mak");
+	string custom_targets_file("custom_targets.mak");
 
-  // Flag indicates using gnu compiler
-  bool useGCC = true;
 
-  // check gnu compiler make or sun compiler make
-  // if first letter of executable is 'g' then gnu otherwise sun
+	bool noDebugFlag(false);//flag tells whether debug info is generated
 
-  char *exename = argv[0];
-  char c;
+	#ifdef _WIN32
+	OS OpSystem(WINDOWS);//defualt to windows makefile
+	#else
+	OS OpSystem(LINUX); //default to linux makefile
+	#endif
 
-  while( (c = *exename++) ) {
-    if(c == '/') {
-      argv[0] = exename;
-    }
-  }
-  if(argv[0][0] == 's') {
-    useGCC = false;
-  }
+	//Compiler defualts to GCC
+	COMPILER Comp(GCC);
 
-  //
-  // Process command line options
-  //
-  while( argc--, *++argv != NULL && **argv == '-' ){
-    if( strcmp( *argv, "-header" ) == 0 && argv[ 1 ] != NULL ){
-      header_file = *++argv;
-      argc--;
-    } else if( strcmp( *argv, "-no-header" ) == 0 ){
-      header_file = "//";
-    } else if( strcmp( *argv, "-programs" ) == 0 && argv[ 1 ] != NULL ){
-      programs_file = *++argv;
-      argc--;
-    } else if( strcmp( *argv, "-no-programs" ) == 0 ){
-      programs_file = "//";
-    } else if( strcmp( *argv, "-custom_targets" ) == 0 && argv[ 1 ] != NULL ){
-      custom_targets_file = *++argv;
-      argc--;
-    } else if( strcmp( *argv, "-no-custom_targets" ) == 0 ){
-      custom_targets_file = "//";
-    } else if(strcmp("-no-debug",*argv) == 0){
-      noDebugFlag = true;
-    } else {
-      switch( *++*argv ){
-      case 'd':
-        debug = true;
-        break;
+	//If first Character of exe is s, then SunCompiler is default
+	string programPath = argv[0];
+	unsigned int i = programPath.find_last_of("/\\");
+	if (i != string::npos && programPath[i + 1] == 's')
+	{
+		Comp=SUN;
+	}
 
-      default:
-        cerr << "Invalid option: -" << **argv << endl;
-        exit( 1 );
-      }
-    }
-  }
+	if(strcmp(argv[1],"-help")==0 || strcmp(argv[1],"-h")==0)
+	{
+		printHelp();
+		exit(0);
+	}
 
-  //
-  // Read the current directory (and cmd line arguments) to find 
-  // file names.
-  //
-  DirList dirlist( argc, argv );
+	//
+	// Process command line options
+	//
+	while (argc--, *++argv != NULL && **argv == '-')
+	{
+		if (strcmp(*argv, "-header") == 0 && argv[1] != NULL)
+		{
+			header_file = *++argv;
+			argc--;
+		}
 
-  //
-  // Now write the makefile
-  //
-  Write write(dirlist, noDebugFlag, useGCC,
-              header_file, programs_file, custom_targets_file);
+		else if (strcmp(*argv,"-win") == 0)
+		{
+			OpSystem = WINDOWS;
+		}
 
-  return 0;
+		else if (strcmp(*argv,"-linux") == 0)
+		{
+			OpSystem=LINUX;
+		}
+
+		else if (strcmp(*argv,"-gcc") == 0)
+		{
+			Comp = GCC;
+		}
+
+		else if (strcmp(*argv,"-sun") == 0)
+		{
+			Comp=SUN;
+		}
+		else if (strcmp(*argv,"-clang") == 0)
+		{
+			Comp=CLANG;
+		}
+
+		else if (strcmp(*argv, "-no-header") == 0)
+		{
+			header_file = "//";
+		}
+
+		else if (strcmp(*argv, "-programs") == 0 && argv[1] != NULL)
+		{
+			programs_file = *++argv;
+			argc--;
+		}
+
+		else if (strcmp(*argv, "-no-programs") == 0)
+		{
+			programs_file = "//";
+		}
+
+		else if (strcmp(*argv, "-custom_targets") == 0 && argv[1] != NULL)
+		{
+			custom_targets_file = *++argv;
+			argc--;
+		}
+
+		else if (strcmp(*argv, "-no-custom_targets") == 0)
+		{
+			custom_targets_file = "//";
+		}
+
+		else if (strcmp("-no-debug", *argv) == 0)
+		{
+			noDebugFlag = true;
+		}
+
+		else
+		{
+
+			cerr << "Invalid option: " << *argv << endl;
+			if(strcmp(*argv,"-help")==0)
+				cerr<<"    -help option must be used alone"<<endl;
+			exit(1);
+		}
+	}
+
+	//
+	// Read the current directory (and cmd line arguments) to find
+	// file names.
+	//
+	DirList dirlist(argc, argv);
+
+	//
+	// Now write the makefile
+	//
+	Write write(dirlist, noDebugFlag, Comp, OpSystem, header_file,
+			programs_file, custom_targets_file);
+
+	return 0;
 }

--- a/makemake/write.h
+++ b/makemake/write.h
@@ -18,34 +18,131 @@
 
 #include <string>
 #include <iostream>
-
 #include "dirlist.h"
 
 using namespace std;
 
-/* Class that writes the makefile
+/**
+ * Enum to describe the Operating System the Makefile will be run on
  */
-class Write {
-public: // Constructor
+enum OS{
+	WINDOWS,//!< WINDOWS cmd.exe
+	LINUX,  //!< LINUX   bash shell
+	NO_OS   //!< NO_OS   not-used
+};
 
-  Write(DirList &dirlist, bool noDebugFlag, bool useGCC,
+/**
+ * Enum to Describe the Compiler being used
+ */
+enum COMPILER{
+	GCC,       //!< GCC
+	CLANG,     //!< CLANG
+	SUN,       //!< SUN
+	NO_COMPILER//!< NO_COMPILER
+};
+
+/**
+ * Class that writes the makefile to stdout
+ */
+class Write
+{
+public:
+
+	/**
+	 * Constructor for the Makefile Writer
+	 * @param dirlist 				The directory listing
+	 * @param noDebugFlag 			True for no debug
+	 * @param comp					The Compiler to Use
+	 * @param sys					The Operaing System
+	 * @param header_file			File containing custom header
+	 * @param programs_file			File Containing cust programs
+	 * @param custom_targets_file	File Containg custom targets
+	 */
+  Write(DirList &dirlist, bool noDebugFlag, const COMPILER comp,const OS sys,
         const string &header_file,
         const string &programs_file,
         const string& custom_targets_file );
 
 private: // Helper functions
 
-  void write_header(bool noDebugFlag, bool useGCC, string header_file);
+  /**
+   * Utility Function which creates the correct mkdir command for a given OS
+   * @param  folderName the name of the directory to make
+   * @return the mkdir command
+   */
+  string mkdir_cmd( const string &folderName);
+
+  /**
+   * Sets the Class member variables foor the given OS and compiler.
+   * TODO Check for OS/Compiler consistency, etc...
+   */
+  void set_system_vars();
+
+  /**
+   * Writes the default Compiler flags to cout.
+   */
+  void write_default_flags();
+
+  /**
+   * Writes Makefile Header to cout
+   * @param header_file the file containing custom header
+   */
+
+  void write_header(string header_file);
+
+  /**
+   * Writes the Lists portion of the Makefile to cout
+   * @param dirlist the directory listing.
+   */
   void write_lists( DirList &dirlist );
+
+/**
+ * Writes the Targets of the makefile
+ * @param dirlist the directory listing
+ * @param programs_file the name of the file containing custom programs
+ * @param custom_targets_file the name of the file containing custom targets
+ */
   void write_main_targets( DirList &dirlist, string programs_file, string custom_targets_file );
-  void write_main_target_list( const set<string> &list,
-                               string compile,
-                               string local_libs );
+
+
+  void write_main_target_list( const set<string> &list,string compile,string local_libs );
+
+
   void write_dependencies( DirList &dirlist );
+
+
   void write_dependency_list( const set<string> &list, DirList &dirlist );
-  void write_trailer( DirList &dirlist, bool useGCC  );
+
+
+  /**
+   * Writes the Trailer portion of the makefile
+   * @param dirlist the directory listing
+   */
+  void write_trailer( DirList &dirlist);
+
 
   set<string> products;
+
+  ///The Compilation Commands
+  string CC,CXX;
+  ///The FLags used for compilation
+  string DEBUGFLAG,CXXFLAGS,CFLAGS,CLIBFLAGS,CCLIBFLAGS;
+
+  string bin_dir;      	///The BinDir variable {Bindir}
+  string bin_suffix;   	///The executable suffix
+  string bin_dir_name; 	///The name of the Output directory
+
+  string Sep;           ///The Path seperator
+  string null_file;     ///The NULL file for the OS
+  string rm_command;    ///The OS delete command
+  string rm_dir_command;///The OS delete directory command
+
+
+  COMPILER Comp;        ///The Compiler to generate flags for
+  OS System;			///The OS to generate commands for
+  bool NoDebugFlags;	///whether or not to generate debug info
+  string CompilerName;	///The Name of the Compiler
+  string OSName;		///The name of the OS
 
 }; // Write
 


### PR DESCRIPTION
Hi, at RIT I use gmakemake quite a lot because it is so easy to use.  However it does not work natively on windows. (The commands it uses are for a bash shell not cmd.exe)

I have added windows compatibility:
- I have tested on both Windows and Linux using the correct options and both create working makefiles.
- If the makemake binary is built on windows it will default to using cmd.exe commands, if it is built on linux it will default to unix commands. (I figure if someone is creating the make file on a specific OS they will probably be building on that OS as well.)
  -Both of these options can be overridden with flags.

I also added a -help flag.

Various refactoring to make it easier to add support for more compilers (aka clang):
- I can create a makefile which builds with clang, however the resulting binary results in a segfault when run. I think it has something to do with the -ansi option.
